### PR TITLE
Upgrade module to support Terraform 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ module "ecr-repository" {
 ## Variables
 
 - `repository_name` - Name of the repository
-- `attach_lifecycle_policy` - If true, an an [ECR lifecycle policy](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html) will be attached (default: `false`)
+- `attach_lifecycle_policy` - If true, an [ECR lifecycle policy](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html) will be attached (default: `false`)
 - `lifecycle_policy` - Contents of the ECR lifecycle policy (default: contents of `default-lifecycle-policy.json.tpl`, untagged images older than 7 days will be deleted)
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -16,16 +16,15 @@ module "ecr-repository" {
 }
 ```
 
-
 ## Variables
 
-- `repository_name` - name of the repository
-- `attach_lifecycle_policy` - attach an [ECR lifecycle policy](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html) (default: `false`)
-- `lifecycle_policy` - ECR lifecycle policy (default: the contents of `default-lifecycle-policy.json.tpl`, untagged images older than 7 days will be deleted)
+- `repository_name` - Name of the repository
+- `attach_lifecycle_policy` - If true, an an [ECR lifecycle policy](https://docs.aws.amazon.com/AmazonECR/latest/userguide/LifecyclePolicies.html) will be attached (default: `false`)
+- `lifecycle_policy` - Contents of the ECR lifecycle policy (default: contents of `default-lifecycle-policy.json.tpl`, untagged images older than 7 days will be deleted)
 
 ## Outputs
 
-- `arn` - full ARN of the repository
-- `name` - the name of the repository
-- `registry_id` - the registry ID where the repository was created
-- `repository_url` - the URL of the repository (in the form aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName)
+- `arn` - Full ARN of the repository
+- `name` - Name of the repository
+- `registry_id` - Registry ID where the repository was created
+- `repository_url` - URL of the repository (in the form aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName)

--- a/main.tf
+++ b/main.tf
@@ -2,12 +2,12 @@
 # ECR Resources
 #
 resource "aws_ecr_repository" "default" {
-  name = "${var.repository_name}"
+  name = var.repository_name
 }
 
 resource "aws_ecr_lifecycle_policy" "default" {
-  count = "${var.attach_lifecycle_policy ? 1 : 0}"
+  count = var.attach_lifecycle_policy ? 1 : 0
 
-  repository = "${aws_ecr_repository.default.name}"
-  policy     = "${var.lifecycle_policy != "" ? var.lifecycle_policy : file("${path.module}/templates/default-lifecycle-policy.json.tpl")}"
+  repository = aws_ecr_repository.default.name
+  policy     = var.lifecycle_policy != "" ? var.lifecycle_policy : file("${path.module}/templates/default-lifecycle-policy.json.tpl")
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,19 @@
 output "arn" {
-  value = "${aws_ecr_repository.default.arn}"
+  value       = aws_ecr_repository.default.arn
+  description = "Full ARN of the repository"
 }
 
 output "name" {
-  value = "${aws_ecr_repository.default.name}"
+  value       = aws_ecr_repository.default.name
+  description = "Name of the repository"
 }
 
 output "registry_id" {
-  value = "${aws_ecr_repository.default.registry_id}"
+  value       = aws_ecr_repository.default.registry_id
+  description = "Registry ID where the repository was created"
 }
 
 output "repository_url" {
-  value = "${aws_ecr_repository.default.repository_url}"
+  value       = aws_ecr_repository.default.repository_url
+  description = "URL of the repository"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "repository_name" {
 variable "attach_lifecycle_policy" {
   default     = false
   type        = bool
-  description = "If true, an an ECR lifecycle policy will be attached"
+  description = "If true, an ECR lifecycle policy will be attached"
 }
 
 variable "lifecycle_policy" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,16 @@
-variable "repository_name" {}
+variable "repository_name" {
+  type        = string
+  description = "Name of the repository"
+}
 
 variable "attach_lifecycle_policy" {
-  default = false
+  default     = false
+  type        = bool
+  description = "If true, an an ECR lifecycle policy will be attached"
 }
 
 variable "lifecycle_policy" {
-  default = ""
+  default     = ""
+  type        = string
+  description = "Contents of the ECR lifecycle policy"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,7 @@
+
+terraform {
+  required_version = ">= 0.12"
+  required_providers {
+    aws = ">= 2.33.0"
+  }
+}


### PR DESCRIPTION
Following the instructions outlined in the Terraform documentation, update the module's configuration to support Terraform 0.12. Despite containing minor changes, this is expected to cause a major version bump, because the changes are not backwards compatible.

Resolves #5 

---

**Testing**

Please use https://github.com/azavea/fieldscope/pull/395 to test this PR.